### PR TITLE
fix: Retry getConnectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "co-request": "^1.0.0",
     "eventemitter2": "^1.0.3",
     "five-bells-shared": "^16.1.0",
+    "lodash": "^4.13.1",
     "mag": "^0.9.1",
     "reconnect-core": "^1.2.0",
     "ws": "^1.1.0"

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -257,11 +257,11 @@ class FiveBellsLedger extends EventEmitter2 {
       throw new Error('Must be connected before getConnectors can be called')
     }
 
-    const res = yield request({
+    const res = yield requestRetry({
       method: 'GET',
       uri: this.id + '/connectors',
       json: true
-    })
+    }, 'Unable to get connectors for ledger ' + this.id, {})
     if (res.statusCode !== 200) {
       throw new Error('Unexpected status code: ' + res.statusCode)
     }


### PR DESCRIPTION
See RILP-650 for background. If the connector tries to crawl ledgers before the ledgers have started (as is often the case when starting ILP server), the `getConnectors` call will error out, resulting in `AssetsNotTradedError`s upon requesting quotes. By retrying, we ensure that any ledgers the connector holds assets on will have a chance to start. cc @sentientwaffle 
