### PR TITLE
fix: set handled flag outside loop

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -426,10 +426,9 @@ class FiveBellsLedger extends EventEmitter2 {
             relatedResources.cancellation_condition_fulfillment)
         }
       }
-
-      if (!handled) {
-        throw new UnrelatedNotificationError('Notification does not seem related to connector')
-      }
+    }
+    if (!handled) {
+      throw new UnrelatedNotificationError('Notification does not seem related to connector')
     }
   }
 

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -294,13 +294,43 @@ describe('PluginBells', function () {
       it('should emit "fulfill_cancellation_condition" on incoming rejected transfers',
         itEmitsFulfillCancellationCondition)
 
-      it('should pass on incoming executed transfers', function * () {
+      it('should pass on incoming prepared transfers', function * () {
+        this.fiveBellsTransferExecuted.expires_at = (new Date()).toISOString()
+        this.fiveBellsTransferExecuted.state = 'prepared'
         this.wsRedLedger.send(JSON.stringify({
           resource: this.fiveBellsTransferExecuted
         }))
 
         yield new Promise((resolve) => this.wsRedLedger.on('message', resolve))
+        sinon.assert.calledOnce(this.stubReceive)
+        sinon.assert.calledWith(this.stubReceive, Object.assign(this.transfer, {
+          expiresAt: this.fiveBellsTransferExecuted.expires_at
+        }))
+      })
 
+      it('should pass on incoming executed transfers', function * () {
+        this.fiveBellsTransferExecuted.expires_at = (new Date()).toISOString()
+        this.wsRedLedger.send(JSON.stringify({
+          resource: this.fiveBellsTransferExecuted
+        }))
+
+        yield new Promise((resolve) => this.wsRedLedger.on('message', resolve))
+        sinon.assert.calledOnce(this.stubReceive)
+        sinon.assert.calledWith(this.stubReceive, Object.assign(this.transfer, {
+          expiresAt: this.fiveBellsTransferExecuted.expires_at
+        }))
+      })
+
+      it('should ignore unrelated credits', function * () {
+        this.fiveBellsTransferExecuted.credits.push({
+          account: 'http://red.example/accounts/george',
+          amount: '10'
+        })
+        this.wsRedLedger.send(JSON.stringify({
+          resource: this.fiveBellsTransferExecuted
+        }))
+
+        yield new Promise((resolve) => this.wsRedLedger.on('message', resolve))
         sinon.assert.calledOnce(this.stubReceive)
         sinon.assert.calledWith(this.stubReceive, this.transfer)
       })


### PR DESCRIPTION
- Don't throw `UnrelatedNotificationError` until all debits have been checked.
- Add some tests
