### PR TITLE
fix: throw error on error in fulfillCondition

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -339,9 +339,9 @@ class FiveBellsLedger extends EventEmitter2 {
     // TODO check the timestamp the ledger sends back
     // See https://github.com/interledger/five-bells-ledger/issues/149
     if (fulfillmentRes.statusCode === 200 || fulfillmentRes.statusCode === 201) {
-      return 'executed'
+      return null
     } else {
-      this.log.error('Failed to submit fulfillment for transfer: ' + transferID + ' Error: ' + (fulfillmentRes.body ? JSON.stringify(fulfillmentRes.body) : fulfillmentRes.error))
+      throw new Error('Failed to submit fulfillment for transfer: ' + transferID + ' Error: ' + (fulfillmentRes.body ? JSON.stringify(fulfillmentRes.body) : fulfillmentRes.error))
     }
   }
 

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -575,12 +575,23 @@ describe('PluginBells', function () {
     })
 
     describe('fulfillCondition', function () {
+      it('errors on improper fulfillment', function (done) {
+        nock('http://red.example')
+          .put('/transfers/6851929f-5a91-4d02-b9f4-4ae6b7f1768c/fulfillment', 'garbage')
+          .reply(203)
+        this.plugin.fulfillCondition('6851929f-5a91-4d02-b9f4-4ae6b7f1768c', 'garbage')
+          .catch((err) => {
+            console.error(err)
+            done()
+          })
+      })
+
       it('puts the fulfillment', function * () {
         nock('http://red.example')
           .put('/transfers/6851929f-5a91-4d02-b9f4-4ae6b7f1768c/fulfillment', 'cf:0:ZXhlY3V0ZQ')
           .reply(201)
-        const state = yield this.plugin.fulfillCondition('6851929f-5a91-4d02-b9f4-4ae6b7f1768c', 'cf:0:ZXhlY3V0ZQ')
-        assert.equal(state, 'executed')
+        const result = yield this.plugin.fulfillCondition('6851929f-5a91-4d02-b9f4-4ae6b7f1768c', 'cf:0:ZXhlY3V0ZQ')
+        assert.equal(result, null)
       })
 
       it('throws an ExternalError on 500', function * () {


### PR DESCRIPTION
Related to interledger/five-bells-connector#193 . Instead of returning a string, `fulfillCondition` resolves a null promise on success and rejects on an error.
