### PR TITLE
refactor: BREAKING adhere to the LedgerPlugin interface

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -203,6 +203,7 @@ class FiveBellsLedger extends EventEmitter2 {
       this.connection.disconnect()
       this.connection = null
     }
+    return Promise.resolve(null)
   }
 
   isConnected () {
@@ -411,21 +412,25 @@ class FiveBellsLedger extends EventEmitter2 {
             : undefined
         })
 
-        if (fiveBellsTransfer.state === 'prepared' ||
-            (fiveBellsTransfer.state === 'executed' && !transfer.executionCondition)) {
-          yield this.emitAsync('receive', transfer)
+        if (fiveBellsTransfer.state === 'prepared') {
+          yield this.emitAsync('incoming_prepare', transfer)
+        }
+        if (fiveBellsTransfer.state === 'executed' && !transfer.executionCondition) {
+          yield this.emitAsync('incoming_transfer', transfer)
         }
 
         if (fiveBellsTransfer.state === 'executed' && relatedResources &&
             relatedResources.execution_condition_fulfillment) {
-          yield this.emitAsync('fulfill_execution_condition', transfer,
+          yield this.emitAsync('incoming_fulfill', transfer,
             relatedResources.execution_condition_fulfillment)
         }
 
         if (fiveBellsTransfer.state === 'rejected' && relatedResources &&
             relatedResources.cancellation_condition_fulfillment) {
-          yield this.emitAsync('fulfill_cancellation_condition', transfer,
+          yield this.emitAsync('incoming_cancel', transfer,
             relatedResources.cancellation_condition_fulfillment)
+        } else if (fiveBellsTransfer.state === 'rejected') {
+          yield this.emitAsync('incoming_cancel', transfer, 'transfer timed out.')
         }
       }
     }
@@ -453,16 +458,25 @@ class FiveBellsLedger extends EventEmitter2 {
             : undefined
         })
 
-        if (fiveBellsTransfer.state === 'executed' &&
-            relatedResources && relatedResources.execution_condition_fulfillment) {
-          yield this.emitAsync('fulfill_execution_condition', transfer,
+        if (fiveBellsTransfer.state === 'prepared') {
+          yield this.emitAsync('outgoing_prepare', transfer)
+        }
+        if (fiveBellsTransfer.state === 'executed' && !transfer.executionCondition) {
+          yield this.emitAsync('outgoing_transfer', transfer)
+        }
+
+        if (fiveBellsTransfer.state === 'executed' && relatedResources &&
+            relatedResources.execution_condition_fulfillment) {
+          yield this.emitAsync('outgoing_fulfill', transfer,
             relatedResources.execution_condition_fulfillment)
         }
 
-        if (fiveBellsTransfer.state === 'rejected' &&
-            relatedResources && relatedResources.cancellation_condition_fulfillment) {
-          yield this.emitAsync('fulfill_cancellation_condition', transfer,
+        if (fiveBellsTransfer.state === 'rejected' && relatedResources &&
+            relatedResources.cancellation_condition_fulfillment) {
+          yield this.emitAsync('outgoing_cancel', transfer,
             relatedResources.cancellation_condition_fulfillment)
+        } else if (fiveBellsTransfer.state === 'rejected') {
+          yield this.emitAsync('outgoing_cancel', transfer, 'transfer timed out.')
         }
       }
     }


### PR DESCRIPTION
Applies changes that make the plugin pass tests in [Ilp-Plugin-Tests](https://github.com/interledger/js-ilp-plugin-tests). The only tests that fail are sending a transfer with an amount of 0, and the tests for the `replyToTransfer` function, which has not been implemented.
