### PR TITLE
feat: add "ledger" property to transfers

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -65,7 +65,7 @@ class FiveBellsLedger extends EventEmitter2 {
 
     if (typeof options.auth.prefix !== 'string') {
       throw new TypeError('Expected options.auth.prefix to be a string, received: ' +
-        typeof options.prefix)
+        typeof options.auth.prefix)
     }
 
     if (options.auth.prefix.slice(-1) !== '.') {
@@ -401,6 +401,7 @@ class FiveBellsLedger extends EventEmitter2 {
           direction: 'incoming',
           // TODO: What if there are multiple debits?
           account: fiveBellsTransfer.debits[0].account,
+          ledger: this.prefix,
           amount: credit.amount,
           data: credit.memo,
           executionCondition: fiveBellsTransfer.execution_condition,
@@ -442,6 +443,7 @@ class FiveBellsLedger extends EventEmitter2 {
           id: fiveBellsTransfer.id.substring(fiveBellsTransfer.id.length - 36),
           direction: 'outgoing',
           account: credit.account,
+          ledger: this.prefix,
           amount: debit.amount,
           data: credit.memo,
           noteToSelf: debit.memo,

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -41,9 +41,9 @@ describe('PluginBells', function () {
     it('should throw when options.prefix is missing', function () {
       assert.throws(() => {
         return new PluginBells({
-          auth: {} // no prefix
+          auth: {prefix: 5} // prefix is wrong type
         })
-      }, 'Expected options.auth.prefix to be a string, received: undefined')
+      }, 'Expected options.auth.prefix to be a string, received: number')
     })
 
     it('should throw when options.prefix is an invalid prefix', function () {
@@ -348,6 +348,7 @@ describe('PluginBells', function () {
           id: 'ac518dfb-b8a6-49ef-b78d-5e26e81d7a45',
           direction: 'incoming',
           account: 'http://red.example/accounts/alice',
+          ledger: 'example.red.',
           amount: '10'
         }
       })
@@ -423,6 +424,7 @@ describe('PluginBells', function () {
           id: 'ac518dfb-b8a6-49ef-b78d-5e26e81d7a45',
           direction: 'outgoing',
           account: 'http://red.example/accounts/alice',
+          ledger: 'example.red.',
           amount: '10'
         }
       })


### PR DESCRIPTION
- Add `ledger` property to transfers so that connectors don't have to. (related to https://github.com/interledger/five-bells-connector/issues/198) 
- Fix a typo in an error message.
