### PR TITLE
fix: [BREAKING] flatten plugin options

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -58,23 +58,24 @@ class FiveBellsLedger extends EventEmitter2 {
       throw new TypeError('Expected an options object, received: ' + typeof options)
     }
 
-    if (typeof options.auth !== 'object') {
-      throw new TypeError('Expected options.auth to be an object, received: ' +
-        typeof options.auth)
+    if (typeof options.prefix !== 'string') {
+      throw new TypeError('Expected options.prefix to be a string, received: ' +
+        typeof options.prefix)
     }
 
-    if (typeof options.auth.prefix !== 'string') {
-      throw new TypeError('Expected options.auth.prefix to be a string, received: ' +
-        typeof options.auth.prefix)
+    if (options.prefix.slice(-1) !== '.') {
+      throw new Error('Expected options.prefix to end with "."')
     }
 
-    if (options.auth.prefix.slice(-1) !== '.') {
-      throw new Error('Expected options.auth.prefix to end with "."')
-    }
-
-    this.prefix = options.auth.prefix
+    this.prefix = options.prefix
     this.host = options.host || null
-    this.credentials = Object.assign({}, options.auth)
+    this.credentials = {
+      account: options.account,
+      password: options.password,
+      cert: options.cert,
+      key: options.key,
+      ca: options.ca
+    }
     this.connector = options.connector || null
 
     this.debugReplyNotifications = options.debugReplyNotifications || false

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -22,11 +22,9 @@ describe('PluginBells', function () {
   describe('constructor', function () {
     it('should succeed with valid configuration', function () {
       const plugin = new PluginBells({
-        auth: {
-          prefix: 'foo.',
-          account: 'http://red.example/accounts/mike',
-          password: 'mike'
-        }
+        prefix: 'foo.',
+        account: 'http://red.example/accounts/mike',
+        password: 'mike'
       })
 
       assert.instanceOf(plugin, PluginBells)
@@ -41,40 +39,28 @@ describe('PluginBells', function () {
     it('should throw when options.prefix is missing', function () {
       assert.throws(() => {
         return new PluginBells({
-          auth: {prefix: 5} // prefix is wrong type
+          prefix: 5 // prefix is wrong type
         })
-      }, 'Expected options.auth.prefix to be a string, received: number')
+      }, 'Expected options.prefix to be a string, received: number')
     })
 
     it('should throw when options.prefix is an invalid prefix', function () {
       assert.throws(() => {
         return new PluginBells({
-          auth: {
-            prefix: 'foo', // no trailing "."
-            account: 'http://red.example/accounts/mike',
-            password: 'mike'
-          }
+          prefix: 'foo', // no trailing "."
+          account: 'http://red.example/accounts/mike',
+          password: 'mike'
         })
-      }, 'Expected options.auth.prefix to end with "."')
-    })
-
-    it('should throw when auth information is missing', function () {
-      assert.throws(() => {
-        return new PluginBells({
-          // no auth
-        })
-      }, 'Expected options.auth to be an object, received: undefined')
+      }, 'Expected options.prefix to end with "."')
     })
   })
 
   describe('instance', function () {
     beforeEach(function * () {
       this.plugin = new PluginBells({
-        auth: {
-          prefix: 'example.red.',
-          account: 'http://red.example/accounts/mike',
-          password: 'mike'
-        }
+        prefix: 'example.red.',
+        account: 'http://red.example/accounts/mike',
+        password: 'mike'
       })
 
       this.infoRedLedger = cloneDeep(require('./data/infoRedLedger.json'))
@@ -155,11 +141,9 @@ describe('PluginBells', function () {
         beforeEach(function () {
           this.plugin = new PluginBells({
             connector: 'http://mark.example',
-            auth: {
-              prefix: 'example.red.',
-              account: 'http://red.example/accounts/mike',
-              password: 'mike'
-            }
+            prefix: 'example.red.',
+            account: 'http://red.example/accounts/mike',
+            password: 'mike'
           })
         })
 
@@ -211,11 +195,9 @@ describe('PluginBells', function () {
   describe('connected instance', function () {
     beforeEach(function * () {
       this.plugin = new PluginBells({
-        auth: {
-          prefix: 'example.red.',
-          account: 'http://red.example/accounts/mike',
-          password: 'mike'
-        },
+        prefix: 'example.red.',
+        account: 'http://red.example/accounts/mike',
+        password: 'mike',
         debugReplyNotifications: true,
         debugAutofund: {
           connector: 'http://mark.example',


### PR DESCRIPTION
Addresses issue https://github.com/interledger/rfcs/issues/55 . Instead of separating pluginOptions into `auth` and other options, the structure is flattened and special fields (such as `store`) are prefixed with an underscore. 
