### PR TITLE
fix: correctly parse address when sending

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -553,7 +553,8 @@ class FiveBellsLedger extends EventEmitter2 {
 
     if (!startsWith(prefix, address)) {
       debug('destination address has invalid prefix', { prefix, address })
-      throw new Error('Destination address must start with ledger prefix')
+      throw new Error('Destination address "' + address + '" must start ' +
+        'with ledger prefix "' + prefix + '"')
     }
 
     const addressParts = address.substr(this.prefix.length).split('.')

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -11,6 +11,7 @@ const UnrelatedNotificationError = require('../errors/unrelated-notification-err
 const EventEmitter2 = require('eventemitter2').EventEmitter2
 const isUndefined = require('lodash/fp/isUndefined')
 const omitUndefined = require('lodash/fp/omitBy')(isUndefined)
+const startsWith = require('lodash/fp/startsWith')
 const map = require('lodash/map')
 const defaults = require('lodash/defaults')
 
@@ -331,7 +332,7 @@ class FiveBellsLedger extends EventEmitter2 {
   }
 
   * _send (transfer) {
-    const sourceAddress = parseAddress(transfer.account)
+    const sourceAddress = yield this.parseAddress(transfer.account)
     const fiveBellsTransfer = omitUndefined({
       id: this.host + '/transfers/' + transfer.id,
       ledger: this.host,
@@ -546,13 +547,21 @@ class FiveBellsLedger extends EventEmitter2 {
       if (templatePath[i] === ':name') return accountPath[i]
     }
   }
-}
 
-function parseAddress (address) {
-  const addressParts = address.split('.')
-  return {
-    ledger: addressParts.slice(0, -1).join('.'),
-    username: addressParts[addressParts.length - 1]
+  * parseAddress (address) {
+    const prefix = yield this.getPrefix()
+
+    if (!startsWith(prefix, address)) {
+      debug('destination address has invalid prefix', { prefix, address })
+      throw new Error('Destination address must start with ledger prefix')
+    }
+
+    const addressParts = address.substr(this.prefix.length).split('.')
+    return {
+      ledger: prefix,
+      username: addressParts.slice(0, 1).join('.'),
+      additionalParts: addressParts.slice(1).join('.')
+    }
   }
 }
 

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -18,7 +18,7 @@ mock('ws', wsHelper.WebSocket)
 const PluginBells = require('..')
 
 describe('PluginBells', function () {
-  afterEach(function () { assert(nock.isDone()) })
+  afterEach(function () { assert(nock.isDone(), 'nock was not called') })
 
   it('should be a class', function () {
     assert.isFunction(PluginBells)
@@ -795,6 +795,16 @@ describe('PluginBells', function () {
           noteToSelf: {source: 'something'},
           data: {foo: 'bar'}
         }), null)
+      })
+
+      it('rejects a transfer when the destination does not begin with the correct prefix', function * () {
+        yield assert.isRejected(this.plugin.send({
+          id: '6851929f-5a91-4d02-b9f4-4ae6b7f1768c',
+          account: 'red.alice',
+          amount: '123',
+          noteToSelf: {source: 'something'},
+          data: {foo: 'bar'}
+        }), /^Error: Destination address "red.alice" must start with ledger prefix "example.red."$/)
       })
 
       it('throws an ExternalError on 400', function (done) {

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -790,7 +790,7 @@ describe('PluginBells', function () {
           .reply(200)
         yield assertResolve(this.plugin.send({
           id: '6851929f-5a91-4d02-b9f4-4ae6b7f1768c',
-          account: 'red.alice',
+          account: 'example.red.alice',
           amount: '123',
           noteToSelf: {source: 'something'},
           data: {foo: 'bar'}
@@ -816,7 +816,7 @@ describe('PluginBells', function () {
 
         this.plugin.send({
           id: '6851929f-5a91-4d02-b9f4-4ae6b7f1768c',
-          account: 'red.alice',
+          account: 'example.red.alice',
           amount: '123'
         }).should.be.rejectedWith('Remote error: status=400').notify(done)
       })
@@ -844,7 +844,7 @@ describe('PluginBells', function () {
 
         yield this.plugin.send({
           id: '6851929f-5a91-4d02-b9f4-4ae6b7f1768c',
-          account: 'red.alice',
+          account: 'example.red.alice',
           amount: '123',
           cases: ['http://notary.example/cases/2cd5bcdb-46c9-4243-ac3f-79046a87a086']
         })
@@ -857,7 +857,7 @@ describe('PluginBells', function () {
 
         this.plugin.send({
           id: '6851929f-5a91-4d02-b9f4-4ae6b7f1768c',
-          account: 'red.alice',
+          account: 'example.red.alice',
           amount: '123',
           cases: ['http://notary.example/cases/2cd5bcdb-46c9-4243-ac3f-79046a87a086']
         }).should.be.rejectedWith('Unexpected status code: 400').notify(done)


### PR DESCRIPTION
The mapping of the ILP address to a local address for `five-bells-ledger` (and probably most ledgers in the future) is defined to be:
- Ensure the prefix matches the expected ledger prefix
- Take the remainder of the address (after the prefix) and call it the local part
- If the local part contains a period, remove the period and anything after it and call it the local account name
- Else call the entire local part the local account name
