### PR TITLE
Allow username to be specified in options

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "DEBUG=ilp-plugin-bells:* istanbul test -- _mocha"
+    "test": "istanbul test -- _mocha"
   },
   "repository": {
     "type": "git",

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -73,6 +73,7 @@ class FiveBellsLedger extends EventEmitter2 {
     this.host = options.host || null
     this.credentials = {
       account: options.account,
+      username: options.username,
       password: options.password,
       cert: options.cert,
       key: options.key,
@@ -109,7 +110,10 @@ class FiveBellsLedger extends EventEmitter2 {
       throw new Error('Failed to resolve ledger URI from account URI')
     }
     this.host = res.body.ledger
-    this.credentials.username = res.body.name
+    // Set the username but don't overwrite the username in case it was provided
+    if (!this.credentials.username) {
+      this.credentials.username = res.body.name
+    }
 
     if (!res.body.connector && this.connector) {
       const res2 = yield this._request({

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -141,6 +141,44 @@ describe('PluginBells', function () {
         nockInfo.done()
       })
 
+      it('should set the username based on the account name returned', function * () {
+        const accountNock = nock('http://red.example')
+          .get('/accounts/mike')
+          .reply(200, {
+            ledger: 'http://red.example',
+            name: 'mike'
+          })
+        const infoNock = nock('http://red.example')
+          .get('/')
+          .reply(200, this.infoRedLedger)
+        yield this.plugin.connect()
+        assert.equal(this.plugin.credentials.username, 'mike')
+        accountNock.done()
+        infoNock.done()
+      })
+
+      it('should not overwrite the username if one is specified in the options', function * () {
+        const accountNock = nock('http://red.example')
+          .get('/accounts/mike')
+          .reply(200, {
+            ledger: 'http://red.example',
+            name: 'mike'
+          })
+        const infoNock = nock('http://red.example')
+          .get('/')
+          .reply(200, this.infoRedLedger)
+        const plugin = new PluginBells({
+          prefix: 'foo.',
+          account: 'http://red.example/accounts/mike',
+          password: 'mike',
+          username: 'xavier'
+        })
+        yield plugin.connect()
+        assert.equal(plugin.credentials.username, 'xavier')
+        accountNock.done()
+        infoNock.done()
+      })
+
       describe('a connector', function () {
         beforeEach(function () {
           this.plugin = new PluginBells({


### PR DESCRIPTION
and don't overwrite username when plugin connects if one was specified. this is needed to use the
plugin-bells using admin credentials on behalf of other accounts.
