### PR TITLE
refactor: move errors from five-bells-shared into ilp-plugin-bells

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "co-request": "^1.0.0",
     "debug": "^2.2.0",
     "eventemitter2": "^1.0.3",
-    "five-bells-shared": "^16.1.0",
     "lodash": "^4.13.1",
     "reconnect-core": "^1.2.0",
     "ws": "^1.1.0"

--- a/src/errors/base-error.js
+++ b/src/errors/base-error.js
@@ -1,0 +1,41 @@
+'use strict'
+
+/**
+ * Extensible error class.
+ *
+ * The built-in Error class is not actually a constructor, but a factory. It
+ * doesn't operate on `this`, so if we call it as `super()` it doesn't do
+ * anything useful.
+ *
+ * Nonetheless it does create objects that are instanceof Error. In order to
+ * easily subclass error we need our own base class which mimics that behavior
+ * but with a true constructor.
+ *
+ * Note that this code is specific to V8 (due to `Error.captureStackTrace`).
+ */
+class BaseError extends Error {
+  constructor (message) {
+    super()
+
+    // Set this.message
+    Object.defineProperty(this, 'message', {
+      configurable: true,
+      enumerable: false,
+      value: message !== undefined ? String(message) : ''
+    })
+
+    // Set this.name
+    Object.defineProperty(this, 'name', {
+      configurable: true,
+      enumerable: false,
+      value: this.constructor.name
+    })
+
+    if (Error.captureStackTrace) {
+      // Set this.stack
+      Error.captureStackTrace(this, this.constructor)
+    }
+  }
+}
+
+module.exports = BaseError

--- a/src/errors/external-error.js
+++ b/src/errors/external-error.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const BaseError = require('five-bells-shared').BaseError
+const BaseError = require('./base-error')
 
 class ExternalError extends BaseError {
 

--- a/src/errors/missing-fulfillment-error.js
+++ b/src/errors/missing-fulfillment-error.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const NotFoundError = require('five-bells-shared').NotFoundError
+const NotFoundError = require('./not-found-error')
 
 class MissingFulfillmentError extends NotFoundError {
   * handler (ctx, log) {

--- a/src/errors/not-found-error.js
+++ b/src/errors/not-found-error.js
@@ -1,0 +1,6 @@
+'use strict'
+
+const BaseError = require('./base-error')
+class NotFoundError extends BaseError {}
+
+module.exports = NotFoundError

--- a/src/errors/transfer-not-found-error.js
+++ b/src/errors/transfer-not-found-error.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const NotFoundError = require('five-bells-shared').NotFoundError
+const NotFoundError = require('./not-found-error')
 
 class TransferNotFoundError extends NotFoundError {
   * handler (ctx, log) {

--- a/src/errors/unprocessable-entity-error.js
+++ b/src/errors/unprocessable-entity-error.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const BaseError = require('./base-error')
+
+class UnprocessableEntityError extends BaseError {
+  * handler (ctx, log) {
+    log.warn('Unprocessable: ' + this.message)
+    ctx.status = 422
+    ctx.body = {
+      id: this.name,
+      message: this.message
+    }
+  }
+}
+
+module.exports = UnprocessableEntityError

--- a/src/errors/unrelated-notification-error.js
+++ b/src/errors/unrelated-notification-error.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const UnprocessableEntityError =
-require('five-bells-shared/errors/unprocessable-entity-error')
+const BaseError = require('./base-error')
+class UnprocessableEntityError extends BaseError {}
 
 class UnrelatedNotificationError extends UnprocessableEntityError {
 


### PR DESCRIPTION
Resolves #39. Includes the error classes that `ilp-plugin-bells` imports from `five-bells-shared` so that it doesn't include large unnecessary dependencies like `five-bells-condition`.
