### PR TITLE
Fix: throw UnreachableError on websocket connection error

### DIFF
--- a/src/errors/unreachable-error.js
+++ b/src/errors/unreachable-error.js
@@ -1,0 +1,6 @@
+'use strict'
+
+const BaseError = require('./base-error')
+class UnreachableError extends BaseError {}
+
+module.exports = UnreachableError


### PR DESCRIPTION
Resolves https://github.com/interledger/js-ilp-plugin-bells/issues/50 . `connect()` should fail if its websocket fails to connect.
