### PR TITLE
Feat: reference accounts by username rather than account URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ const factory = new PluginBellsFactory({
 factory.connect().then(() => {
 
   // `create` will make a new, connected, PluginBells instance. If a plugin is already
-  // created for a given account, then the existing plugin is returned from `create`
+  // created for a given username, then the existing plugin is returned from `create`
 
-  const account = 'https://red.ilpdemo.org/ledger/accounts/alice'
-  const plugin = factory.create({ account })
+  const plugin = factory.create({ username: 'alice' })
 
   const client = new Client(plugin)
 
@@ -73,5 +72,5 @@ factory.connect().then(() => {
   // when you're done using the plugin, call factory.remove in order to
   // get rid of all event listeners and stop caching the plugin.
 
-  factory.remove(account)
+  factory.remove('alice')
 })

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "debug": "^2.2.0",
     "eventemitter2": "^1.0.3",
     "lodash": "^4.13.1",
+    "path-to-regexp": "^1.6.0",
     "reconnect-core": "^1.2.0",
     "ws": "^1.1.0"
   }

--- a/test/factorySpec.js
+++ b/test/factorySpec.js
@@ -112,9 +112,7 @@ describe('PluginBellsFactory', function () {
         .reply(404, {})
 
       try {
-        yield this.factory.create({
-          account: 'http://red.example/accounts/bob'
-        })
+        yield this.factory.create({ username: 'bob' })
         assert(false, 'factory create should have failed')
       } catch (e) {
         nockBob.done()
@@ -133,17 +131,13 @@ describe('PluginBellsFactory', function () {
           name: 'admin'
         })
 
-      const plugin = yield this.factory.create({
-        account: 'http://red.example/accounts/mike'
-      })
+      const plugin = yield this.factory.create({ username: 'mike' })
 
       nockMike.done()
       assert.isObject(plugin)
       assert.isTrue(plugin.isConnected())
 
-      const plugin2 = yield this.factory.create({
-        account: 'http://red.example/accounts/mike'
-      })
+      const plugin2 = yield this.factory.create({ username: 'mike' })
 
       assert.equal(plugin, plugin2, 'only one plugin should be made per account')
     })
@@ -159,9 +153,7 @@ describe('PluginBellsFactory', function () {
           name: 'admin'
         })
 
-      const pluginMike = yield this.factory.create({
-        account: 'http://red.example/accounts/mike'
-      })
+      const pluginMike = yield this.factory.create({ username: 'mike' })
 
       nockMike.done()
 
@@ -189,9 +181,7 @@ describe('PluginBellsFactory', function () {
           name: 'admin'
         })
 
-      const pluginMike = yield this.factory.create({
-        account: 'http://red.example/accounts/mike'
-      })
+      const pluginMike = yield this.factory.create({ username: 'mike' })
 
       nockMike.done()
 
@@ -223,9 +213,7 @@ describe('PluginBellsFactory', function () {
           name: 'admin'
         })
 
-      yield this.factory.create({
-        account: 'http://red.example/accounts/mike'
-      })
+      yield this.factory.create({ username: 'mike' })
 
       nockMike.done()
 


### PR DESCRIPTION
Parses the ledger's account endpoint in order to get account URIs instead of the user providing them.
