### PR TITLE
Fix: send messages/transfers from the right account

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -341,7 +341,8 @@ class FiveBellsLedger extends EventEmitter2 {
     const destinationAddress = yield this.parseAddress(message.account)
     const fiveBellsMessage = {
       ledger: this.host,
-      account: this.urls.account.replace(':name', encodeURIComponent(destinationAddress.username)),
+      from: this.urls.account.replace(':name', encodeURIComponent(this.credentials.username)),
+      to: this.urls.account.replace(':name', encodeURIComponent(destinationAddress.username)),
       data: message.data
     }
 
@@ -654,7 +655,7 @@ class FiveBellsLedger extends EventEmitter2 {
     this._validateMessage(message)
     return this.emitAsync('incoming_message', {
       ledger: this.prefix,
-      account: this.prefix + this.accountUriToName(message.account),
+      account: this.prefix + this.accountUriToName(message.account || message.to),
       data: message.data
     })
   }

--- a/test/data/message.json
+++ b/test/data/message.json
@@ -1,5 +1,6 @@
 {
   "ledger": "http://red.example",
-  "account": "http://red.example/accounts/alice",
+  "from": "http://red.example/accounts/mike",
+  "to": "http://red.example/accounts/alice",
   "data": { "foo": "bar" }
 }


### PR DESCRIPTION
Uses the new `to` and `from` fields in messaging in order to send from the correct account, even when logged in as admin.