### PR TITLE
Fix: allow differing credentials and plugin account

### DIFF
--- a/src/lib/factory.js
+++ b/src/lib/factory.js
@@ -198,7 +198,13 @@ class PluginFactory {
     const plugin = new Plugin({
       username: opts.username,
       password: null,
-      account: account
+      account: account,
+      credentials: {
+        // make sure that the plugin uses admin credentials
+        username: this.adminUsername,
+        password: this.adminPassword,
+        account: this.adminAccount
+      }
     })
 
     // 'connects' the plugin without really connecting it

--- a/test/factorySpec.js
+++ b/test/factorySpec.js
@@ -15,7 +15,7 @@ const cloneDeep = require('lodash/cloneDeep')
 mock('ws', wsHelper.WebSocket)
 const PluginBellsFactory = require('..').Factory
 
-describe.only('PluginBellsFactory', function () {
+describe('PluginBellsFactory', function () {
   beforeEach(function * () {
     this.wsAdmin = new wsHelper.Server('ws://red.example/accounts/admin/transfers')
     this.wsRedLedger = new wsHelper.Server('ws://red.example/accounts/*/transfers')
@@ -190,6 +190,7 @@ describe.only('PluginBellsFactory', function () {
           ledger: 'http://red.example',
           data: { foo: 'bar' }
         })
+        .basicAuth({user: 'admin', pass: 'admin'})
         .reply(200)
 
       yield this.plugin.sendMessage({
@@ -202,6 +203,7 @@ describe.only('PluginBellsFactory', function () {
     it('sends a transfer with the correct fields', function * () {
       nock('http://red.example')
         .put('/transfers/' + this.transfer.id, this.fiveBellsTransferAlice)
+        .basicAuth({user: 'admin', pass: 'admin'})
         .reply(200)
 
       yield this.plugin.sendTransfer(this.transfer)


### PR DESCRIPTION
`this.credentials` is only used for authentication, while fields like `username` and `account` used to identify the plugin are stored in `this.username` and `this.account`. The factory uses this in order to give its plugins admin credentials, because it hasn't got their passwords.