### PR TITLE
Fix: use the to/from format for messages

### DIFF
--- a/src/lib/factory.js
+++ b/src/lib/factory.js
@@ -126,8 +126,11 @@ class PluginFactory {
       accounts = accounts.concat(notification.resource.debits
         .map((c) => (c.account)))
     } else if (notification.type === 'message') {
-      // add account
-      accounts.push(notification.resource.account)
+      // add receiver
+      accounts.push(notification.resource.to)
+
+      // add the sender
+      accounts.push(notification.resource.from)
     }
 
     // for every account in the notification, call that plugin's notification

--- a/test/factorySpec.js
+++ b/test/factorySpec.js
@@ -168,7 +168,8 @@ describe('PluginBellsFactory', function () {
         type: 'message',
         resource: {
           ledger: 'http://red.example',
-          account: 'http://red.example/accounts/mike',
+          to: 'http://red.example/accounts/mike',
+          from: 'http://red.example/accounts/alice',
           data: {}
         },
         related_resources: {}


### PR DESCRIPTION
expects message notifications with `to` and `from` rather than `account`.