### PR TITLE
Feat: allow login with webfinger indentifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,11 @@ npm install --save ilp ilp-plugin-bells
 const Client = require('ilp').Client
 
 const client = new Client({
-  type: 'bells',
-  auth: {
-    prefix: 'ilpdemo.red.',
-    // Account URI
-    account: 'https://red.ilpdemo.org/ledger/accounts/alice',
-    password: 'alice'
-  }
+  _plugin: require('ilp-plugin-bells'),
+
+  // a webfinger identifier can be used to resolve account information
+  identifier: 'alice@red.ilpdemo.org',
+  password: 'alice'
 })
 ```
 


### PR DESCRIPTION
Instead of requiring `account`, `username`, and `password`, you can use a webfinger identifier in the form `username@ledger.example` (the same one used to send in the `ilp-kit`). The old credential format is still supported.