### PR TITLE
chore: switch to integration-test-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "istanbul test -- _mocha",
-    "integration": "integration all"
+    "integration": "integration-loader && integration all"
   },
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "eslint-config-standard": "^5.3.1",
     "eslint-plugin-promise": "^1.3.1",
     "eslint-plugin-standard": "^1.3.2",
-    "five-bells-integration-test": "^4.1.1",
+    "five-bells-integration-test-loader": "^1.0.0",
     "ghooks": "^1.2.1",
     "istanbul": "^0.4.3",
     "mocha": "^2.5.3",
@@ -52,6 +52,10 @@
     },
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
+    },
+    "five-bells-integration-test-loader": {
+      "module": "five-bells-integration-test",
+      "repo": "interledgerjs/five-bells-integration-test"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Currently, we have to bump the version of integration tests on every module, every time we change them. We also often get into deadlocks we have to resolve by skipping tests.

This is part of a series of pull requests to switch to five-bells-integration-test-loader, which will solve both problems by loading the integration tests according to the same rules as other modules: Use latest master, unless there is a branch of the same name, then use that branch.

It's probably easiest to understand by looking at the following two links:
* interledgerjs/five-bells-ledger@b241d14768b02a42a34dc42e91d5101db7de0525
* https://github.com/interledgerjs/five-bells-integration-test-loader