### PR TITLE
feat: add timeout to cap connect() retries

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -176,7 +176,7 @@ class FiveBellsLedger extends EventEmitter2 {
       uri: accountUri,
       json: true
     }, {
-      errorMessage: 'Failed to resolve ledger URI from account URI',
+      errorMessage: 'Unable to connect to account',
       timeout: options.timeout
     })
 

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -526,7 +526,7 @@ describe('Connection methods', function () {
         .reply(404)
 
       return assert.isRejected(this.plugin.connect(),
-        /Error: Failed to resolve ledger URI from account URI/)
+        /Error: Unable to connect to account/)
     })
 
     it('fails if the retries exceed the timeout', function () {
@@ -534,7 +534,7 @@ describe('Connection methods', function () {
         .get('/accounts/mike')
         .replyWithError('fail')
       return assert.isRejected(this.plugin.connect({timeout: 1000}),
-        /Error: Failed to resolve ledger URI from account URI: timeout/)
+        /Error: Unable to connect to account: timeout/)
     })
 
     it('fails when options.timeout is invalid', function () {

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -53,6 +53,15 @@ describe('Connection methods', function () {
       assert.isTrue(this.plugin.isConnected())
     })
 
+    it('doesn\'t connect when the "account" is invalid', function (done) {
+      const plugin = new PluginBells({
+        prefix: 'example.red.',
+        account: 'foo',
+        password: 'mike'
+      })
+      plugin.connect().should.be.rejectedWith(Error, 'Invalid account URI').notify(done)
+    })
+
     it('doesn\'t connect when ws server is down', function () {
       nock('http://red.example')
         .get('/')
@@ -518,6 +527,20 @@ describe('Connection methods', function () {
 
       return assert.isRejected(this.plugin.connect(),
         /Error: Failed to resolve ledger URI from account URI/)
+    })
+
+    it('fails if the retries exceed the timeout', function () {
+      const plugin = new PluginBells({
+        prefix: 'example.red.',
+        account: 'http://red.example/accounts/mike',
+        password: 'mike',
+        connectTimeout: 1000
+      })
+      nock('http://red.example')
+        .get('/accounts/mike')
+        .replyWithError('fail')
+      return assert.isRejected(plugin.connect(),
+        /Error: Failed to resolve ledger URI from account URI: timeout/)
     })
   })
 

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -530,17 +530,17 @@ describe('Connection methods', function () {
     })
 
     it('fails if the retries exceed the timeout', function () {
-      const plugin = new PluginBells({
-        prefix: 'example.red.',
-        account: 'http://red.example/accounts/mike',
-        password: 'mike',
-        connectTimeout: 1000
-      })
       nock('http://red.example')
         .get('/accounts/mike')
         .replyWithError('fail')
-      return assert.isRejected(plugin.connect(),
+      return assert.isRejected(this.plugin.connect({timeout: 1000}),
         /Error: Failed to resolve ledger URI from account URI: timeout/)
+    })
+
+    it('fails when options.timeout is invalid', function () {
+      assert.throws(() => {
+        this.plugin.connect({timeout: 'test'})
+      }, 'Expected options.timeout to be a number, received: string')
     })
   })
 

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -55,6 +55,17 @@ describe('PluginBells constructor', function () {
         })
       }, 'Expected options.prefix to end with "."')
     })
+
+    it('should throw when options.connectTimeout is invalid', function () {
+      assert.throws(() => {
+        return new PluginBells({
+          prefix: 'example.red.', // no trailing "."
+          account: 'http://red.example/accounts/mike',
+          password: 'mike',
+          connectTimeout: 'test'
+        })
+      }, 'Expected options.connectTimeout to be a number, received: string')
+    })
   })
 })
 

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -55,17 +55,6 @@ describe('PluginBells constructor', function () {
         })
       }, 'Expected options.prefix to end with "."')
     })
-
-    it('should throw when options.connectTimeout is invalid', function () {
-      assert.throws(() => {
-        return new PluginBells({
-          prefix: 'example.red.', // no trailing "."
-          account: 'http://red.example/accounts/mike',
-          password: 'mike',
-          connectTimeout: 'test'
-        })
-      }, 'Expected options.connectTimeout to be a number, received: string')
-    })
   })
 })
 


### PR DESCRIPTION
Also, malformed `account` URLs will fail immediately.

Fixes https://github.com/interledgerjs/ilp-plugin-bells/issues/73