### PR TITLE
feat: BREAKING: make plugin.get{Account,Info} sync

### DIFF
--- a/src/lib/ledger-context.js
+++ b/src/lib/ledger-context.js
@@ -35,11 +35,17 @@ function parseAndValidateLedgerUrls (metadataUrls) {
 class LedgerContext {
   constructor (host, ledgerMetadata) {
     this.host = host
+    this.ledgerMetadata = ledgerMetadata
     this.urls = parseAndValidateLedgerUrls(ledgerMetadata.urls)
     debug('using service urls:', this.urls)
     this.prefix = ledgerMetadata.ilp_prefix
-    this.info = {
-      connectors: ledgerMetadata.connectors,
+  }
+
+  getInfo () {
+    const ledgerMetadata = this.ledgerMetadata
+    return {
+      prefix: this.prefix,
+      connectors: ledgerMetadata.connectors.map((c) => this.prefix + c.name),
       precision: ledgerMetadata.precision,
       scale: ledgerMetadata.scale,
       currencyCode: ledgerMetadata.currency_code,

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -241,6 +241,58 @@ describe('Connection methods', function () {
       })
     })
 
+    describe('info', function () {
+      it('loads the info from the ledger metadata', function * () {
+        nock('http://red.example')
+          .get('/accounts/mike')
+          .reply(200, {
+            ledger: 'http://red.example',
+            name: 'mike'
+          })
+        nock('http://red.example')
+          .get('/auth_token')
+          .reply(200, {token: 'abc'})
+        nock('http://red.example')
+          .get('/')
+          .reply(200, this.infoRedLedger)
+        yield this.plugin.connect()
+        assert.deepEqual(this.plugin.getInfo(), {
+          prefix: 'example.red.',
+          connectors: ['example.red.mark'],
+          currencyCode: 'USD',
+          currencySymbol: '$',
+          precision: 2,
+          scale: 4
+        })
+      })
+
+      it('throws an ExternalError when info returns 500', function () {
+        nock('http://red.example')
+          .get('/accounts/mike')
+          .reply(200, {
+            ledger: 'http://red.example',
+            name: 'mike'
+          })
+        nock('http://red.example')
+          .get('/')
+          .reply(500)
+        return assert.isRejected(this.plugin.connect(), /ExternalError: Unable to determine ledger precision/)
+      })
+
+      it('throws an ExternalError when the precision is missing', function () {
+        nock('http://red.example')
+          .get('/accounts/mike')
+          .reply(200, {
+            ledger: 'http://red.example',
+            name: 'mike'
+          })
+        nock('http://red.example')
+          .get('/')
+          .reply(200, {scale: 4})
+        return assert.isRejected(this.plugin.connect(), /ExternalError: Unable to determine ledger precision/)
+      })
+    })
+
     it('should set urls from object in ledger metadata and strip unnecessary values', function * () {
       nock('http://red.example')
         .get('/auth_token')
@@ -599,7 +651,9 @@ describe('Connection methods', function () {
 
   describe('getAccount (not connected)', function () {
     it('throws if not connected', function * () {
-      return assert.isRejected(this.plugin.getAccount(), /Must be connected before getAccount can be called/)
+      assert.throws(() => {
+        this.plugin.getAccount()
+      }, /Must be connected before getAccount can be called/)
     })
   })
 

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -77,6 +77,32 @@ describe('Connection methods', function () {
       return this.plugin.connect().should.be.rejected
     })
 
+    it('rejects with ExternalError when info returns 500', function () {
+      nock('http://red.example')
+        .get('/accounts/mike')
+        .reply(200, {
+          ledger: 'http://red.example',
+          name: 'mike'
+        })
+      nock('http://red.example')
+        .get('/')
+        .reply(500)
+      return this.plugin.connect().should.be.rejectedWith(ExternalError, /Unable to determine ledger precision/)
+    })
+
+    it('rejects with ExternalError when info is missing precision', function () {
+      nock('http://red.example')
+        .get('/accounts/mike')
+        .reply(200, {
+          ledger: 'http://red.example',
+          name: 'mike'
+        })
+      nock('http://red.example')
+        .get('/')
+        .reply(200, {scale: 4})
+      return this.plugin.connect().should.be.rejectedWith(ExternalError, /Unable to determine ledger precision/)
+    })
+
     it('ignores if called twice in series', function * () {
       nock('http://red.example')
         .get('/auth_token')
@@ -276,7 +302,7 @@ describe('Connection methods', function () {
         nock('http://red.example')
           .get('/')
           .reply(500)
-        return assert.isRejected(this.plugin.connect(), /ExternalError: Unable to determine ledger precision/)
+        return assert.isRejected(this.plugin.connect(), ExternalError, /Unable to determine ledger precision/)
       })
 
       it('throws an ExternalError when the precision is missing', function () {
@@ -289,7 +315,7 @@ describe('Connection methods', function () {
         nock('http://red.example')
           .get('/')
           .reply(200, {scale: 4})
-        return assert.isRejected(this.plugin.connect(), /ExternalError: Unable to determine ledger precision/)
+        return assert.isRejected(this.plugin.connect(), ExternalError, /Unable to determine ledger precision/)
       })
     })
 

--- a/test/helpers/ws.js
+++ b/test/helpers/ws.js
@@ -19,7 +19,9 @@ class MockWebSocket extends EventEmitter {
   }
 
   send (msg) {
-    this.sock.send(msg)
+    process.nextTick(() => {
+      this.sock.send(msg)
+    })
   }
 
   handleOpen () {
@@ -31,7 +33,9 @@ class MockWebSocket extends EventEmitter {
   }
 
   handleMessage (evt) {
-    this.emit('message', evt.data, {})
+    process.nextTick(() => {
+      this.emit('message', evt.data, {})
+    })
   }
 
   handleError (err) {

--- a/test/infoSpec.js
+++ b/test/infoSpec.js
@@ -10,7 +10,6 @@ const mock = require('mock-require')
 const nock = require('nock')
 const wsHelper = require('./helpers/ws')
 const cloneDeep = require('lodash/cloneDeep')
-const ExternalError = require('../src/errors/external-error')
 
 mock('ws', wsHelper.WebSocket)
 const PluginBells = require('..')
@@ -68,20 +67,6 @@ describe('Info methods', function () {
         scale: 4
       }
       assert.deepEqual(this.plugin.getInfo(), info)
-    })
-
-    it.skip('throws an ExternalError on 500', function () {
-      nock('http://red.example')
-        .get('/')
-        .reply(500)
-      return assert.isRejected(this.plugin.getInfo(), ExternalError, /Unable to determine ledger precision/)
-    })
-
-    it.skip('throws an ExternalError when the precision is missing', function () {
-      nock('http://red.example')
-        .get('/')
-        .reply(200, {scale: 4})
-      return assert.isRejected(this.plugin.getInfo(), ExternalError, /Unable to determine ledger precision/)
     })
 
     it('throws if not connected', function * () {

--- a/test/infoSpec.js
+++ b/test/infoSpec.js
@@ -58,21 +58,16 @@ describe('Info methods', function () {
   })
 
   describe('getInfo', function () {
-    it('gets the precision and scale', function * () {
+    it('gets the precision and scale', function () {
       const info = {
-        connectors: [{
-          id: 'http://red.example/accounts/mark',
-          name: 'mark',
-          connector: 'http://connector.example'
-        }],
+        prefix: 'example.red.',
+        connectors: ['example.red.mark'],
         currencyCode: 'USD',
         currencySymbol: '$',
         precision: 2,
         scale: 4
       }
-      yield assert.eventually.deepEqual(this.plugin.getInfo(), info)
-      // The result is cached.
-      yield assert.eventually.deepEqual(this.plugin.getInfo(), info)
+      assert.deepEqual(this.plugin.getInfo(), info)
     })
 
     it.skip('throws an ExternalError on 500', function () {
@@ -88,20 +83,19 @@ describe('Info methods', function () {
         .reply(200, {scale: 4})
       return assert.isRejected(this.plugin.getInfo(), ExternalError, /Unable to determine ledger precision/)
     })
-  })
 
-  describe('getPrefix', function () {
-    it('returns the plugin\'s prefix', function * () {
-      yield assert.isFulfilled(this.plugin.getPrefix(), 'example.red.')
-    })
-
-    it('fails without any prefix', function * () {
+    it('throws if not connected', function * () {
       const plugin = new PluginBells({
-        // no prefix
         account: 'http://red.example/accounts/mike',
         password: 'mike'
       })
-      return assert.isRejected(plugin.getPrefix(), /Must be connected before getPrefix can be called/)
+      assert.throws(() => {
+        plugin.getInfo()
+      }, 'Must be connected before getInfo can be called')
+    })
+
+    it('includes the plugin\'s prefix', function * () {
+      assert.equal(this.plugin.getInfo().prefix, 'example.red.')
     })
 
     it('cannot connect without any prefix', function * () {
@@ -199,14 +193,14 @@ describe('Info methods', function () {
       this.wsRedLedger = wsHelper.makeServer('ws://blue.example/websocket?token=abc')
 
       yield plugin.connect()
-      yield assert.isFulfilled(plugin.getPrefix(), 'example.blue.')
+      assert.equal(plugin.getInfo().prefix, 'example.blue.')
       yield plugin.disconnect()
     })
   })
 
   describe('getAccount', function () {
     it('returns the plugin\'s account', function * () {
-      yield assert.isFulfilled(this.plugin.getAccount(), 'example.red.mike')
+      assert.equal(this.plugin.getAccount(), 'example.red.mike')
     })
 
     it('fails without any prefix', function () {
@@ -215,7 +209,9 @@ describe('Info methods', function () {
         account: 'http://red.example/accounts/mike',
         password: 'mike'
       })
-      return assert.isRejected(plugin.getAccount(), /Must be connected before getAccount can be called/)
+      assert.throws(() => {
+        plugin.getAccount()
+      }, /Must be connected before getAccount can be called/)
     })
   })
 


### PR DESCRIPTION
* Remove `getPrefix` (and add `prefix` to `getInfo`).
* `LedgerInfo#connectors` is now an array of `IlpAddress`.
* Related to https://github.com/interledger/rfcs/pull/143