### PR TITLE
Fix: better error message when failing to connect to account

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -194,7 +194,11 @@ class FiveBellsLedger extends EventEmitter2 {
     })
 
     if (!res.body.ledger) {
-      throw new Error('Failed to resolve ledger URI from account URI')
+      throw new Error('Failed to fetch account details from "' +
+        accountUri +
+        '". Got: "' +
+        JSON.stringify(res.body) +
+        '"')
     }
     const host = res.body.ledger
     // Set the username but don't overwrite the username in case it was provided

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -154,7 +154,7 @@ describe('Connection methods', function () {
         .get('/accounts/mike')
         .reply(200, { name: 'mike' })
 
-      return assert.isRejected(this.plugin.connect(), /Failed to resolve ledger URI from account URI/)
+      return assert.isRejected(this.plugin.connect(), /Failed to fetch account details from/)
     })
 
     it('should set the username based on the account name returned', function * () {


### PR DESCRIPTION
`Failed to resolve ledger URI from account URI` isn't very helpful.