### PR TITLE
Fix: correctly assign fields in message notification

### DIFF
--- a/src/lib/translate.js
+++ b/src/lib/translate.js
@@ -167,9 +167,9 @@ const translateMessageNotification = (message, account, ledgerContext) => {
     'incoming_message',
     {
       ledger: ledgerContext.prefix,
-      account: ledgerContext.prefix + ledgerContext.accountUriToName(message.account || message.to),
+      account: ledgerContext.prefix + ledgerContext.accountUriToName(message.from),
       from: ledgerContext.prefix + ledgerContext.accountUriToName(message.from),
-      to: ledgerContext.prefix + ledgerContext.accountUriToName(message.account || message.to),
+      to: ledgerContext.prefix + ledgerContext.accountUriToName(message.to),
       data: message.data
     }
   ]

--- a/test/notificationSpec.js
+++ b/test/notificationSpec.js
@@ -492,7 +492,11 @@ describe('Notification handling', function () {
 
       yield new Promise((resolve) => this.wsRedLedger.on('message', resolve))
       sinon.assert.calledOnce(this.stubIncomingMessage)
-      sinon.assert.calledWith(this.stubIncomingMessage, this.message)
+
+      // the account on an incoming transfer should indicate the sender
+      sinon.assert.calledWith(this.stubIncomingMessage, Object.assign({},
+        this.message,
+        { account: this.message.from }))
     })
   })
 


### PR DESCRIPTION
`message.account` is the sender of the message, so it shouldn't be used as the `to` field.