### PR TITLE
fix: account parsing when ledger url has port

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "eventemitter2": "^2.2.2",
     "five-bells-shared": "^21.2.0",
     "lodash": "^4.13.1",
-    "path-to-regexp": "^1.6.0",
     "reconnect-core": "^1.2.0",
     "ws": "^1.1.0"
   }


### PR DESCRIPTION
path-to-regexp was being used to convert the account URL template into a
regex, but it was not working with ledgers whose URLs contain ports.
this changes it to use the ledgerContext.accountUriToName function,
which does not have this problem