### PR TITLE
fix(factory): correct basic auth when querying account URL

### DIFF
--- a/src/lib/factory.js
+++ b/src/lib/factory.js
@@ -148,13 +148,14 @@ class PluginFactory extends EventEmitter2 {
 
     // make sure that the account exists
     const exists = yield request(account, {
-      headers: {
-        Authorization: this.adminUsername + ':' + this.adminPassword
+      auth: {
+        username: this.adminUsername,
+        password: this.adminPassword
       }
     })
 
     if (exists.statusCode !== 200) {
-      const msg = 'account ' + account + ' cannot be reached: ' + exists.statusCode
+      const msg = 'account ' + account + ' cannot be reached: ' + exists.statusCode + ' ' + JSON.stringify(exists.body)
       debug(msg)
       throw new UnreachableError(msg)
     }

--- a/test/factorySpec.js
+++ b/test/factorySpec.js
@@ -94,6 +94,10 @@ describe('PluginBellsFactory', function () {
 
       const nockMike = nock('http://red.example')
         .get('/accounts/mike')
+        .basicAuth({
+          user: 'admin',
+          pass: 'admin'
+        })
         .reply(200, {
           ledger: 'http://red.example',
           name: 'admin'
@@ -236,6 +240,10 @@ describe('PluginBellsFactory', function () {
       it('subscribes to the new account', function (done) {
         nock('http://red.example')
           .get('/accounts/mary')
+          .basicAuth({
+            user: 'admin',
+            pass: 'admin'
+          })
           .reply(200, {
             ledger: 'http://red.example',
             name: 'admin'


### PR DESCRIPTION
the factory was incorrectly providing the admin username and password in plaintext instead of base64-encoded, as required by HTTP Basic Auth. the auth helper in the request library does this automatically