### PR TITLE
fix(factory): use less strict username regex

### DIFF
--- a/src/lib/factory.js
+++ b/src/lib/factory.js
@@ -132,8 +132,8 @@ class PluginFactory extends EventEmitter2 {
 
     const username = opts.username || this.ledgerContext.accountUriToName(opts.account)
 
-    if (typeof username !== 'string' || !/^[a-z0-9]([a-z0-9]|[-](?!-)){0,18}[a-z0-9]$/.test(username)) {
-      throw new Error('Invalid username')
+    if (typeof username !== 'string' || !/^[a-zA-Z0-9_-]{1,86}$/.test(username)) {
+      throw new Error('Invalid username: ' + username)
     }
 
     // try to retrieve existing plugin

--- a/test/factorySpec.js
+++ b/test/factorySpec.js
@@ -227,6 +227,19 @@ describe('PluginBellsFactory', function () {
         assert.equal(this.plugin, plugin, 'account should resolve to same username')
       })
 
+      it('will allow a username with underscores and dashes', function * () {
+        const username = 'mike_12-34'
+        const nockMike = nock('http://red.example')
+          .get('/accounts/' + username)
+          .reply(200)
+        assert.isObject(this.plugin)
+        assert.isTrue(this.plugin.isConnected())
+
+        const plugin = yield this.factory.create({ account: 'http://red.example/accounts/' + username })
+        assert.equal(plugin.username, username, 'account should resolve to same username')
+        nockMike.done()
+      })
+
       it('throws an error when account and username are both supplied', function (done) {
         this.factory.create({
           username: 'mike',
@@ -267,7 +280,7 @@ describe('PluginBellsFactory', function () {
 
       it('will throw if given an invalid opts.username', function (done) {
         this.factory.create({ username: 'foo!' }).catch((err) => {
-          assert.equal(err.message, 'Invalid username')
+          assert.equal(err.message, 'Invalid username: foo!')
           done()
         })
       })


### PR DESCRIPTION
as mentioned in https://github.com/interledgerjs/five-bells-shared/pull/177, the stricter username

regex should only be applied by the ledger at account creation time