### PR TITLE
Feat: support the "to" field in addition to "account"

### DIFF
--- a/src/lib/translate.js
+++ b/src/lib/translate.js
@@ -288,7 +288,7 @@ const translateMessageNotification = (message, account, ledgerContext) => {
 }
 
 const translatePluginApiToBells = (transfer, account, ledgerContext) => {
-  const sourceAddress = ledgerContext.parseAddress(transfer.account)
+  const sourceAddress = ledgerContext.parseAddress(transfer.to || transfer.account)
   const fiveBellsAmount = (new BigNumber(transfer.amount))
     .shift(-ledgerContext.getInfo().scale)
     .toString()

--- a/test/messageSpec.js
+++ b/test/messageSpec.js
@@ -6,6 +6,7 @@ chai.use(chaiAsPromised)
 chai.should()
 
 const assert = chai.assert
+const expect = chai.expect
 
 const mock = require('mock-require')
 const nock = require('nock')
@@ -71,6 +72,24 @@ describe('Messaging', function () {
         .basicAuth({user: 'mike', pass: 'mike'})
         .reply(200)
       yield assert.isFulfilled(this.plugin.sendMessage(this.message), null)
+    })
+
+    it('submits a message with "to" instead of "account"', function * () {
+      nock('http://red.example')
+        .post('/messages', this.ledgerMessage)
+        .basicAuth({user: 'mike', pass: 'mike'})
+        .reply(200)
+
+      this.message.to = this.message.account
+      delete this.message.account
+
+      yield assert.isFulfilled(this.plugin.sendMessage(this.message), null)
+    })
+
+    it('won\'t submit a message with both "to" and "account"', function * () {
+      this.message.to = this.message.account
+      yield expect(assert.isFulfilled(this.plugin.sendMessage(this.message), null))
+        .to.be.rejectedWith(/"to" and "account" cannot both be defined/)
     })
 
     it('should use the message url from the ledger metadata', function * () {

--- a/test/transferSpec.js
+++ b/test/transferSpec.js
@@ -6,6 +6,7 @@ chai.use(chaiAsPromised)
 chai.should()
 
 const assert = chai.assert
+const expect = chai.expect
 
 const mock = require('mock-require')
 const nock = require('nock')
@@ -72,6 +73,24 @@ describe('Transfer methods', function () {
         .basicAuth({user: 'mike', pass: 'mike'})
         .reply(200)
       yield assert.isFulfilled(this.plugin.sendTransfer(this.transfer), null)
+    })
+
+    it('submits a transfer with "to" instead of "account"', function * () {
+      nock('http://red.example')
+        .put('/transfers/6851929f-5a91-4d02-b9f4-4ae6b7f1768c', this.ledgerTransfer)
+        .basicAuth({user: 'mike', pass: 'mike'})
+        .reply(200)
+
+      this.transfer.to = this.transfer.account
+      delete this.transfer.account
+
+      yield assert.isFulfilled(this.plugin.sendTransfer(this.transfer), null)
+    })
+
+    it('won\'t submit a transfer with both "to" and "account"', function * () {
+      this.transfer.to = this.transfer.account
+      yield expect(assert.isFulfilled(this.plugin.sendTransfer(this.transfer), null))
+        .to.be.rejectedWith(/"to" and "account" cannot both be defined/)
     })
 
     it('should use the transfer url from the ledger metadata', function * () {


### PR DESCRIPTION
To comply with the new LPI. New code should be using the `to` field instead of `account` in transfers and messages.