### PR TITLE
Fix websocket reconnection

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -288,6 +288,7 @@ class FiveBellsLedger extends EventEmitter2 {
                 // Re-subscribe to our account activity in case the ledger forgot us
                 // and only then emit 'connect' and resolve the promise
                 return this._subscribeAccounts([this.account])
+                  .catch(reject)
                   .then(() => {
                     this.emit('connect')
                     this.connected = true
@@ -702,7 +703,13 @@ class FiveBellsLedger extends EventEmitter2 {
       this.on('_rpc:response', listener)
       const rpcMessage = JSON.stringify({ jsonrpc: '2.0', id: requestId, method, params })
       debug('sending RPC message', rpcMessage)
-      this.ws.send(rpcMessage)
+      // If sending rejects we can reject immediately
+      this.ws.send(rpcMessage, (err) => {
+        if (err) {
+          debug('ws error sending rpc request:', err)
+          return reject(err)
+        }
+      })
     })
   }
 

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -33,8 +33,9 @@ describe('Connection methods', function () {
   })
 
   afterEach(function * () {
+    this.plugin.disconnect()
     this.wsRedLedger.stop()
-    assert(nock.isDone(), 'nock should be called')
+    assert.isTrue(nock.isDone(), 'nock should be called')
   })
 
   describe('connect', function () {
@@ -91,8 +92,11 @@ describe('Connection methods', function () {
         .reply(200, {token: 'abc'})
 
       this.wsRedLedger.stop()
-      this.wsRedLedger = new mockSocket.Server('ws://red.example/websocket?token=abc')
+      // Unclear why but if this test overwrites this.wsRedLedger
+      // it causes other tests to fail
+      const wsRedLedger = new mockSocket.Server('ws://red.example/websocket?token=abc')
       yield this.plugin.connect({ timeout: 10 }).should.be.rejectedWith(Error, /timed out before "connect"/)
+      wsRedLedger.stop()
     })
 
     it('doesn\'t connect when the "account" is invalid', function (done) {
@@ -731,6 +735,67 @@ describe('Connection methods', function () {
           assert.equal(this.plugin.isConnected(), true)
           resolve()
         }, 150)
+      })
+    })
+
+    describe('websocket reconnection', function () {
+      beforeEach(function * () {
+        nock('http://red.example')
+          .get('/accounts/mike')
+          .reply(200, {
+            ledger: 'http://red.example',
+            name: 'mike'
+          })
+        nock('http://red.example')
+          .get('/')
+          .reply(200, this.infoRedLedger)
+        nock('http://red.example')
+          .get('/auth_token')
+          .reply(200, {token: 'abc'})
+
+        yield this.plugin.connect()
+      })
+
+      afterEach(function () {
+        assert.equal(nock.isDone(), true, 'nocks must be used')
+      })
+
+      it('should reconnect if the websocket connection gets an error', function * () {
+        const spyConnection = sinon.spy()
+        this.wsRedLedger.on('connection', spyConnection)
+        this.wsRedLedger.emit('error', 'blah')
+        yield new Promise((resolve) => setTimeout(resolve, 10))
+        assert.equal(spyConnection.callCount, 1)
+      })
+
+      it('should reconnect if the websocket connection closes', function * () {
+        const spyConnection = sinon.spy()
+        this.wsRedLedger.on('connection', spyConnection)
+        this.wsRedLedger.emit('close')
+        yield new Promise((resolve) => setTimeout(resolve, 10))
+        assert.equal(spyConnection.callCount, 1)
+      })
+
+      it('should reconnect if the websocket connection keeps closing', function * () {
+        const realImmediate = setImmediate
+        const clock = sinon.useFakeTimers()
+        const spyConnection = sinon.spy()
+        const spyDisconnect = sinon.spy()
+        const spyConnect = sinon.spy()
+        this.wsRedLedger.on('connection', spyConnection)
+        this.plugin.on('disconnect', spyDisconnect)
+        this.plugin.on('connect', spyConnect)
+        for (let i = 1; i < 10; i++) {
+          this.wsRedLedger.emit('close')
+          // it actually uses a fibonacci backoff
+          // but it won't be more than 50ms in the first 10 times
+          clock.tick(50)
+          yield new Promise((resolve) => realImmediate(resolve))
+          assert.equal(spyConnection.callCount, i)
+          assert.equal(spyDisconnect.callCount, i)
+          assert.equal(spyConnect.callCount, i)
+        }
+        clock.restore()
       })
     })
   })

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -128,6 +128,28 @@ describe('Connection methods', function () {
       wsRedLedger.stop()
     })
 
+    it('should reject if sending the subscription request fails', function * () {
+      nock('http://red.example')
+        .get('/accounts/mike')
+        .reply(200, {
+          ledger: 'http://red.example',
+          name: 'mike'
+        })
+      nock('http://red.example')
+        .get('/')
+        .reply(200, this.infoRedLedger)
+      nock('http://red.example')
+        .get('/auth_token')
+        .reply(200, {token: 'abc'})
+
+      this.wsRedLedger.on('connection', () => {
+        sinon.stub(this.plugin.ws, 'send')
+          .callsArgWith(1, new Error('blah'))
+      })
+
+      yield this.plugin.connect().should.be.rejectedWith(Error, /blah/)
+    })
+
     it('doesn\'t connect when the "account" is invalid', function (done) {
       const plugin = new PluginBells({
         prefix: 'example.red.',


### PR DESCRIPTION
* make sure that the ws connection is reopened when it drops
* only consider the plugin connected after it has sent the subscribe message and gotten a confirmation back
* catch errors from ws.send

Once this is approved I'll also create a PR to patch the current version being used with ilp-kit

resolves https://github.com/interledgerjs/ilp-plugin-bells/issues/113