### PR TITLE
Improve websocket (re)connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /coverage/
 /integration-test/
 *.log
+*.swp
 

--- a/src/lib/factory.js
+++ b/src/lib/factory.js
@@ -207,8 +207,11 @@ class PluginFactory extends EventEmitter2 {
     // delete all listeners to stop memory leaks
     this.plugins.get(username).removeAllListeners()
     this.plugins.delete(username)
-    // TODO should we resubscribe without that account included?
-    return Promise.resolve(null)
+    if (this.globalSubscription) {
+      return Promise.resolve(null)
+    } else {
+      return this._subscribeAccounts()
+    }
   }
 
   _pluginAccounts () {
@@ -226,9 +229,6 @@ class PluginFactory extends EventEmitter2 {
       return this.adminPlugin._subscribeAllAccounts()
     } else {
       const accounts = this._pluginAccounts()
-      if (accounts.length === 0) {
-        return Promise.resolve()
-      }
       debug('subscribing to accounts: ' + accounts.join(', '))
       return this.adminPlugin._subscribeAccounts(accounts)
     }

--- a/src/lib/factory.js
+++ b/src/lib/factory.js
@@ -50,12 +50,14 @@ class PluginFactory extends EventEmitter2 {
       this.adminPlugin.on('_rpc:notification', (notif) =>
         co.wrap(this._routeNotification).call(this, notif))
 
-      this.adminPlugin.on('connect', this._subscribeAccounts.bind(this))
+      this.adminPlugin.on('connect', () => {
+        debug('admin plugin connected')
+        this._subscribeAccounts()
+      })
     }
 
     debug('connecting admin plugin')
     yield this.adminPlugin.connect(options)
-    // TODO wait to resolve until we have subscribed to accounts
 
     // store the shared context
     this.ledgerContext = this.adminPlugin.ledgerContext
@@ -136,7 +138,10 @@ class PluginFactory extends EventEmitter2 {
 
     // try to retrieve existing plugin
     const existing = this.plugins.get(username)
-    if (existing) return existing
+    if (existing) {
+      debug('tried to create plugin that already exists, returning existing plugin for user: ' + username)
+      return existing
+    }
 
     // parse endpoint to get URL
     const account = opts.account || this.ledgerContext

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -275,11 +275,17 @@ class FiveBellsLedger extends EventEmitter2 {
             }
 
             if (rpcMessage.method === 'connect') {
-              if (!this.connected) {
-                this.emit('connect')
-                this.connected = true
+              if (this.connected) {
+                return resolve(null)
+              } else {
+                return this._subscribeAccounts([this.account])
+                  .catch(reject)
+                  .then(() => {
+                    this.emit('connect')
+                    this.connected = true
+                    return resolve(null)
+                  })
               }
-              return resolve(null)
             }
             co.wrap(this._handleIncomingRpcMessage)
               .call(this, rpcMessage)
@@ -335,7 +341,6 @@ class FiveBellsLedger extends EventEmitter2 {
     ])
 
     return connectTimeoutRace
-      .then(() => this._subscribeAccounts([this.account]))
   }
 
   disconnect () {

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -180,7 +180,7 @@ class FiveBellsLedger extends EventEmitter2 {
     })
   }
 
-  _connectToWebsocket(options) {
+  _connectToWebsocket (options) {
     const wsUri = options.uri
     const timeout = options.timeout
     const reconnectOptions = {
@@ -786,6 +786,5 @@ function * requestRetry (requestOptions, retryOptions) {
   debug('http request failed. aborting.')
   throw new Error(retryOptions.errorMessage)
 }
-
 
 module.exports = FiveBellsLedger

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -289,6 +289,7 @@ class FiveBellsLedger extends EventEmitter2 {
                 return this._subscribeAccounts([this.account])
                   .catch(reject)
                   .then(() => {
+                    debug('plugin connected to: ' + notificationsUrl)
                     this.emit('connect')
                     this.connected = true
                     return resolve(null)
@@ -336,6 +337,7 @@ class FiveBellsLedger extends EventEmitter2 {
             this.ws = ws
           })
           .on('disconnect', () => {
+            debug('plugin disconnected from: ' + notificationsUrl)
             this.connected = false
             // remove listeners so we don't have duplicate event handlers when the ws reconnects
             this.ws.removeAllListeners()

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -677,7 +677,12 @@ class FiveBellsLedger extends EventEmitter2 {
       this.on('_rpc:response', listener)
       const rpcMessage = JSON.stringify({ jsonrpc: '2.0', id: requestId, method, params })
       debug('sending RPC message', rpcMessage)
-      this.ws.send(rpcMessage)
+      this.ws.send(rpcMessage, (err) => {
+        if (err) {
+          debug('error sending RPC message', err)
+          reject(err)
+        }
+      })
     })
   }
 

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -76,6 +76,28 @@ describe('Connection methods', function () {
       assert.isTrue(this.plugin.isConnected())
     })
 
+    it('should reject if sending the subscription request fails', function * () {
+      nock('http://red.example')
+        .get('/accounts/mike')
+        .reply(200, {
+          ledger: 'http://red.example',
+          name: 'mike'
+        })
+      nock('http://red.example')
+        .get('/')
+        .reply(200, this.infoRedLedger)
+      nock('http://red.example')
+        .get('/auth_token')
+        .reply(200, {token: 'abc'})
+
+      this.wsRedLedger.on('connection', () => {
+        sinon.stub(this.plugin.ws, 'send')
+          .callsArgWith(1, new Error('blah'))
+      })
+
+      yield this.plugin.connect().should.be.rejectedWith(Error, /blah/)
+    })
+
     it('times out connection', function * () {
       nock('http://red.example')
         .get('/accounts/mike')

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -33,6 +33,7 @@ describe('Connection methods', function () {
   })
 
   afterEach(function * () {
+    yield this.plugin.disconnect()
     this.wsRedLedger.stop()
     assert(nock.isDone(), 'nock should be called')
   })
@@ -760,31 +761,67 @@ describe('Connection methods', function () {
       }, 'Expected options.timeout to be a number, received: string')
     })
 
-    it('reconnects if the socket is closed', function * () {
-      nock('http://red.example')
-        .get('/accounts/mike')
-        .reply(200, {
-          ledger: 'http://red.example',
-          name: 'mike'
-        })
-      nock('http://red.example')
-        .get('/')
-        .reply(200, this.infoRedLedger)
-      nock('http://red.example')
-        .get('/auth_token')
-        .reply(200, {token: 'abc'})
+    describe('websocket reconnection', function () {
+      beforeEach(function * () {
+        nock('http://red.example')
+          .get('/accounts/mike')
+          .reply(200, {
+            ledger: 'http://red.example',
+            name: 'mike'
+          })
+        nock('http://red.example')
+          .get('/')
+          .reply(200, this.infoRedLedger)
+        nock('http://red.example')
+          .get('/auth_token')
+          .reply(200, {token: 'abc'})
+      })
 
-      assert.equal(this.plugin.isConnected(), false)
-      yield this.plugin.connect()
-      assert.equal(this.plugin.isConnected(), true)
-      this.plugin.ws.close()
-      assert.equal(this.plugin.isConnected(), false)
-      yield new Promise((resolve, reject) => {
-        // Wait for the plugin to reconnect.
-        setTimeout(() => {
-          assert.equal(this.plugin.isConnected(), true)
-          resolve()
-        }, 150)
+      it('reconnects if the socket is closed', function * () {
+        assert.equal(this.plugin.isConnected(), false)
+        yield this.plugin.connect()
+        assert.equal(this.plugin.isConnected(), true)
+        this.wsRedLedger.emit('close')
+        assert.equal(this.plugin.isConnected(), false)
+        yield new Promise((resolve, reject) => {
+          // Wait for the plugin to reconnect.
+          setTimeout(() => {
+            assert.equal(this.plugin.isConnected(), true)
+            resolve()
+          }, 20)
+        })
+      })
+
+      it('should reconnect if the websocket connection gets an error', function * () {
+        yield this.plugin.connect()
+        const spyConnection = sinon.spy()
+        this.wsRedLedger.on('connection', spyConnection)
+        this.wsRedLedger.emit('error', 'blah')
+        yield new Promise((resolve) => setTimeout(resolve, 20))
+        assert.equal(spyConnection.callCount, 1)
+      })
+
+      it('should reconnect if the websocket connection keeps closing', function * () {
+        yield this.plugin.connect()
+        const realImmediate = setImmediate
+        const clock = sinon.useFakeTimers()
+        const spyConnection = sinon.spy()
+        const spyDisconnect = sinon.spy()
+        const spyConnect = sinon.spy()
+        this.wsRedLedger.on('connection', spyConnection)
+        this.plugin.on('disconnect', spyDisconnect)
+        this.plugin.on('connect', spyConnect)
+        for (let i = 1; i < 10; i++) {
+          this.wsRedLedger.emit('close')
+          // it actually uses a fibonacci backoff
+          // but it won't be more than 500ms
+          clock.tick(500)
+          yield new Promise((resolve) => realImmediate(resolve))
+          assert.equal(spyConnection.callCount, i, 'server did not get the right number of connections')
+          assert.equal(spyDisconnect.callCount, i, 'plugin did not emit disconnect when it was supposed to')
+          assert.equal(spyConnect.callCount, i, 'plugin did not emit connect when it was supposed to')
+        }
+        clock.restore()
       })
     })
   })

--- a/test/factorySpec.js
+++ b/test/factorySpec.js
@@ -614,7 +614,7 @@ describe('PluginBellsFactory', function () {
         yield subscribedPromise
       })
 
-      it.skip('should resolve only after subscribing to the accounts', function * () {
+      it('should resolve only after subscribing to the accounts', function * () {
         const connectPromise = this.factory.connect().then(() => 'connect')
         const subscribedPromise = new Promise((resolve, reject) => {
           this.wsRedLedger.on('message', (message) => {
@@ -742,10 +742,13 @@ describe('PluginBellsFactory', function () {
     describe('websocket reconnection', function () {
       it('will resubscribe to all accounts if the websocket connection drops', function * () {
         yield this.factory.connect()
+        this.wsRedLedger.emit('close')
+        yield new Promise(setImmediate)
 
         const subscribedPromise = new Promise((resolve, reject) => {
           this.wsRedLedger.on('message', (message) => {
             const parsed = JSON.parse(message)
+            console.log(parsed)
             if (parsed.method === 'subscribe_all_accounts' && parsed.params.eventType === '*') {
               resolve()
             }

--- a/test/helpers/ws.js
+++ b/test/helpers/ws.js
@@ -60,6 +60,12 @@ exports.makeServer = function (uri) {
         id: rpcMessage.id,
         result: rpcMessage.params.accounts.length
       }))
+    } else if (rpcMessage.method === 'subscribe_all_accounts') {
+      server.send(JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpcMessage.id,
+        result: 1
+      }))
     }
   })
   return server


### PR DESCRIPTION
* handle errors when sending subscription message
* make sure to (re)send the subscription message each time the plugin tries to connect
* reconnect faster when the websocket disconnects

resolves https://github.com/interledgerjs/ilp-plugin-bells/issues/113
replaces https://github.com/interledgerjs/ilp-plugin-bells/pull/117, for which the integration tests kept failing