### PR TITLE
fix: re-raise account retry delay

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.6.0
+    version: 6.9.1
 test:
   override:
     # Run lint

--- a/src/lib/ledger-context.js
+++ b/src/lib/ledger-context.js
@@ -48,10 +48,8 @@ class LedgerContext {
     return {
       prefix: this.prefix,
       connectors: ledgerMetadata.connectors.map((c) => this.prefix + c.name),
-      precision: ledgerMetadata.precision,
-      scale: ledgerMetadata.scale,
       currencyCode: ledgerMetadata.currency_code,
-      currencySymbol: ledgerMetadata.currency_symbol
+      currencyScale: ledgerMetadata.scale // this is the name for it in the fivebells API, for legacy reasons
     }
   }
 

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -321,7 +321,7 @@ class FiveBellsLedger extends EventEmitter2 {
   * _fetchLedgerMetadata (host) {
     debug('request ledger metadata %s', host)
     function throwErr () {
-      throw new ExternalError('Unable to determine ledger precision')
+      throw new ExternalError('Unable to determine ledger metadata')
     }
 
     let res
@@ -334,8 +334,11 @@ class FiveBellsLedger extends EventEmitter2 {
       }
     }
 
-    if (!res || res.statusCode !== 200) throwErr()
-    if (!res.body.precision || !res.body.scale) throwErr()
+    if (!res || res.statusCode !== 200) { throwErr() }
+
+    // note that the fivebells ledger API uses 'scale' instead of 'currency_scale'.
+    // fields like 'ilp_prefix' and 'currency_code' are not mandatory
+    if (!res.body.connectors || !res.body.scale) { throwErr() }
 
     return res.body
   }
@@ -368,7 +371,7 @@ class FiveBellsLedger extends EventEmitter2 {
       throw new ExternalError('Unable to determine current balance')
     }
     const ledgerBalance = new BigNumber(res.body.balance)
-    const integerBalance = ledgerBalance.shift(this.ledgerContext.getInfo().scale)
+    const integerBalance = ledgerBalance.shift(this.ledgerContext.getInfo().currencyScale)
     return integerBalance.toString()
   }
 

--- a/src/lib/translate.js
+++ b/src/lib/translate.js
@@ -145,7 +145,9 @@ const translateTransferNotification = (
       // TODO: What if there are multiple debits?
       const debit = fiveBellsTransfer.debits[0]
 
-      const integerAmount = (new BigNumber(credit.amount)).shift(ledgerContext.getInfo().scale)
+      // for legacy reasons, the FiveBells ledger API uses float values for amounts of debits and credits,
+      // which need to be multiplied by currencyScale to get their integer value in ledger units.
+      const integerAmount = (new BigNumber(credit.amount)).shift(ledgerContext.getInfo().currencyScale)
       const transfer = omitNil({
         id: fiveBellsTransfer.id.substring(fiveBellsTransfer.id.length - 36),
         direction: 'incoming',
@@ -211,7 +213,9 @@ const translateTransferNotification = (
       //       credits/debits?
       const credit = fiveBellsTransfer.credits[0]
 
-      const integerAmount = (new BigNumber(debit.amount)).shift(ledgerContext.getInfo().scale)
+      // for legacy reasons, the FiveBells ledger API uses float values for amounts of debits and credits,
+      // which need to be multiplied by currencyScale to get their integer value in ledger units.
+      const integerAmount = (new BigNumber(credit.amount)).shift(ledgerContext.getInfo().currencyScale)
       const transfer = omitNil({
         id: fiveBellsTransfer.id.substring(fiveBellsTransfer.id.length - 36),
         direction: 'outgoing',
@@ -289,8 +293,9 @@ const translateMessageNotification = (message, account, ledgerContext) => {
 
 const translatePluginApiToBells = (transfer, account, ledgerContext) => {
   const sourceAddress = ledgerContext.parseAddress(transfer.to)
-  const fiveBellsAmount = (new BigNumber(transfer.amount))
-    .shift(-ledgerContext.getInfo().scale)
+  // for legacy reasons, the FiveBells ledger API uses float values for amounts of debits and credits,
+  // which need to be multiplied by currencyScale to get their integer value in ledger units.
+  const fiveBellsAmount = (new BigNumber(transfer.amount)).shift(-ledgerContext.getInfo().currencyScale)
     .toString()
   return omitNil({
     id: ledgerContext.urls.transfer.replace(':id', transfer.id),

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -58,6 +58,9 @@ describe('Connection methods', function () {
     })
 
     it('retries if account gives 500', function * () {
+      const clock = sinon.useFakeTimers('setTimeout')
+      // run the clock extra fast
+      const clockInterval = setInterval(() => clock.tick(1000), 1)
       nock('http://red.example')
         .get('/accounts/mike')
         .reply(500)
@@ -75,6 +78,8 @@ describe('Connection methods', function () {
 
       yield assert.isFulfilled(this.plugin.connect(), null, 'should be fulfilled with null')
       assert.isTrue(this.plugin.isConnected())
+      clearInterval(clockInterval)
+      clock.restore()
     })
 
     it('should reject if sending the subscription request fails', function * () {

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -184,20 +184,7 @@ describe('Connection methods', function () {
       nock('http://red.example')
         .get('/')
         .reply(500)
-      return this.plugin.connect().should.be.rejectedWith(ExternalError, /Unable to determine ledger precision/)
-    })
-
-    it('rejects with ExternalError when info is missing precision', function () {
-      nock('http://red.example')
-        .get('/accounts/mike')
-        .reply(200, {
-          ledger: 'http://red.example',
-          name: 'mike'
-        })
-      nock('http://red.example')
-        .get('/')
-        .reply(200, {scale: 4})
-      return this.plugin.connect().should.be.rejectedWith(ExternalError, /Unable to determine ledger precision/)
+      return this.plugin.connect().should.be.rejectedWith(ExternalError, /Unable to determine ledger metadata/)
     })
 
     it('ignores if called twice in series', function * () {
@@ -401,9 +388,7 @@ describe('Connection methods', function () {
           prefix: 'example.red.',
           connectors: ['example.red.mark'],
           currencyCode: 'USD',
-          currencySymbol: '$',
-          precision: 10,
-          scale: 2
+          currencyScale: 2
         })
       })
 
@@ -417,20 +402,7 @@ describe('Connection methods', function () {
         nock('http://red.example')
           .get('/')
           .reply(500)
-        return assert.isRejected(this.plugin.connect(), ExternalError, /Unable to determine ledger precision/)
-      })
-
-      it('throws an ExternalError when the precision is missing', function () {
-        nock('http://red.example')
-          .get('/accounts/mike')
-          .reply(200, {
-            ledger: 'http://red.example',
-            name: 'mike'
-          })
-        nock('http://red.example')
-          .get('/')
-          .reply(200, {scale: 4})
-        return assert.isRejected(this.plugin.connect(), ExternalError, /Unable to determine ledger precision/)
+        return assert.isRejected(this.plugin.connect(), ExternalError, /Unable to determine ledger metadata/)
       })
     })
 

--- a/test/data/infoRedLedger.json
+++ b/test/data/infoRedLedger.json
@@ -1,6 +1,6 @@
 {
+  "currency_code": "USD",
   "scale": 2,
-  "precision": 10,
   "connectors": [
     {
       "id": "http://red.example/accounts/mark",
@@ -8,8 +8,6 @@
       "connector": "http://connector.example"
     }
   ],
-  "currency_code": "USD",
-  "currency_symbol": "$",
   "urls": {
     "health": "http://red.example/health",
     "transfer": "http://red.example/transfers/:id",

--- a/test/factorySpec.js
+++ b/test/factorySpec.js
@@ -43,7 +43,7 @@ describe('PluginBellsFactory', function () {
           id: 'ac518dfb-b8a6-49ef-b78d-5e26e81d7a45',
           direction: 'incoming',
           to: 'example.red.alice',
-          amount: '1000',
+          amount: '1234', // ledger units, so that's 12.34 USD
           expiresAt: (new Date((new Date()).getTime() + 1000)).toISOString()
         }
       }
@@ -56,12 +56,12 @@ describe('PluginBellsFactory', function () {
         ledger: 'http://red.example',
         debits: [{
           account: 'http://red.example/accounts/mike',
-          amount: '10',
+          amount: '12.34',
           authorized: true
         }],
         credits: [{
           account: 'http://red.example/accounts/alice',
-          amount: '10'
+          amount: '12.34'
         }],
         expires_at: this.transfer.current.expiresAt
       }
@@ -71,11 +71,11 @@ describe('PluginBellsFactory', function () {
         ledger: 'http://red.example',
         debits: [{
           account: 'http://red.example/accounts/alice',
-          amount: '10'
+          amount: '12.34'
         }],
         credits: [{
           account: 'http://red.example/accounts/mike',
-          amount: '10'
+          amount: '12.34'
         }],
         state: 'executed'
       }
@@ -401,7 +401,7 @@ describe('PluginBellsFactory', function () {
 
         it(`sends a ${format}-format transfer with the correct fields`, function * () {
           nock('http://red.example')
-            .put('/transfers/' + this.transfer.current.id, this.fiveBellsTransferAlice)
+            .put('/transfers/' + this.transfer[format].id, this.fiveBellsTransferAlice)
             .basicAuth({user: 'admin', pass: 'admin'})
             .reply(200)
 
@@ -538,7 +538,7 @@ describe('PluginBellsFactory', function () {
           id: 'ac518dfb-b8a6-49ef-b78d-5e26e81d7a45',
           direction: 'incoming',
           to: 'example.red.alice',
-          amount: '1000',
+          amount: '12.34',
           expiresAt: (new Date((new Date()).getTime() + 1000)).toISOString()
         }
       }

--- a/test/infoSpec.js
+++ b/test/infoSpec.js
@@ -57,14 +57,12 @@ describe('Info methods', function () {
   })
 
   describe('getInfo', function () {
-    it('gets the precision and scale', function () {
+    it('gets the currencyCode and currencyScale', function () {
       const info = {
         prefix: 'example.red.',
         connectors: ['example.red.mark'],
         currencyCode: 'USD',
-        currencySymbol: '$',
-        precision: 10,
-        scale: 2
+        currencyScale: 2
       }
       assert.deepEqual(this.plugin.getInfo(), info)
     })


### PR DESCRIPTION
the previous commit lowered the retry delay because i thought it was being used to retry fulfillments. however, it turned out that that delay was only being used for querying the account. setting too short a delay causes the integration tests to fail, so this re-raises the delay to 1 second minimum but makes it clear that that retry value is only for querying the account