### PR TITLE
fix: disable HTTP2

### DIFF
--- a/src/lib/factory.js
+++ b/src/lib/factory.js
@@ -198,7 +198,6 @@ class PluginFactory extends EventEmitter2 {
 
     plugin.ledgerContext = this.ledgerContext
 
-    plugin.agent = this.adminPlugin.agent
     this.plugins.set(username, plugin)
 
     if (!this.glogbalSubscription) {


### PR DESCRIPTION
The spdy module has a problem of falling back to HTTP/1.1. Therefore, the HTTP2 code is removed until the fallback to HTTP/1.1 is solved.