### PR TITLE
Feat: use message.data as a fallback if no ilp

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -522,6 +522,7 @@ class FiveBellsLedger extends EventEmitter2 {
       from: this.ledgerContext.urls.account.replace(':name', encodeURIComponent(this.username)),
       to: this.ledgerContext.urls.account.replace(':name', encodeURIComponent(destinationAddress.username)),
       ilp: message.ilp,
+      data: { id: message.id, ilp: message.ilp, custom: message.custom },
       custom: message.custom
     }
     debug('converted to ledger message: ' + JSON.stringify(fiveBellsMessage))

--- a/src/lib/translate.js
+++ b/src/lib/translate.js
@@ -285,10 +285,10 @@ const translateMessageNotification = (message, account, ledgerContext) => {
       ledger: ledgerContext.prefix,
       from: ledgerContext.prefix + ledgerContext.accountUriToName(message.from),
       to: ledgerContext.prefix + ledgerContext.accountUriToName(message.to),
-      ilp: message.ilp,
-      custom: message.custom
+      ilp: message.ilp || (message.data && message.data.ilp),
+      custom: message.custom || (message.data && message.data.custom)
     },
-    message.id
+    message.id || (message.data && message.data.id)
   ]
 }
 

--- a/test/data/message-with-all.json
+++ b/test/data/message-with-all.json
@@ -1,0 +1,13 @@
+{
+  "id": "6a13abf0-2333-4d1e-9afc-5bf32c6dc0dd",
+  "ledger": "http://red.example",
+  "from": "http://red.example/accounts/mike",
+  "to": "http://red.example/accounts/alice",
+  "ilp": "aGVsbG8=",
+  "data": {
+    "ilp": "aGVsbG8=",
+    "id": "6a13abf0-2333-4d1e-9afc-5bf32c6dc0dd",
+    "custom": { "foo": "bar" }
+  },
+  "custom": { "foo": "bar" }
+}

--- a/test/data/message-with-data.json
+++ b/test/data/message-with-data.json
@@ -1,0 +1,10 @@
+{
+  "ledger": "http://red.example",
+  "from": "http://red.example/accounts/mike",
+  "to": "http://red.example/accounts/alice",
+  "data": {
+    "ilp": "aGVsbG8=",
+    "id": "6a13abf0-2333-4d1e-9afc-5bf32c6dc0dd",
+    "custom": { "foo": "bar" }
+  }
+}

--- a/test/messageSpec.js
+++ b/test/messageSpec.js
@@ -44,7 +44,7 @@ describe('Messaging', function () {
       .reply(403)
 
     this.infoRedLedger = cloneDeep(require('./data/infoRedLedger.json'))
-    this.ledgerMessage = cloneDeep(require('./data/message.json'))
+    this.ledgerMessage = cloneDeep(require('./data/message-with-all.json'))
     this.message = {
       id: '6a13abf0-2333-4d1e-9afc-5bf32c6dc0dd',
       ledger: 'example.red.',

--- a/test/notificationSpec.js
+++ b/test/notificationSpec.js
@@ -574,6 +574,23 @@ describe('Notification handling', function () {
       sinon.assert.calledWith(this.stubIncomingRequest, this.message)
     })
 
+    it('emits "incoming_request" with data instead of ilp', function * () {
+      const altMessage = cloneDeep(require('./data/message-with-data.json'))
+      this.wsRedLedger.send(JSON.stringify({
+        jsonrpc: '2.0',
+        id: null,
+        method: 'notify',
+        params: {
+          event: 'message.send',
+          resource: altMessage
+        }
+      }))
+
+      yield new Promise((resolve) => this.wsRedLedger.on('message', resolve))
+      sinon.assert.calledOnce(this.stubIncomingRequest)
+      sinon.assert.calledWith(this.stubIncomingRequest, this.message)
+    })
+
     it('emits "incoming_response"', function * () {
       nock('http://red.example')
         .post('/messages', this.fiveBellsMessage)


### PR DESCRIPTION
Supports old version of the five bells ledger API where there are no `id`, `ilp`, nor `custom` fields. It will send message calls that have both `data` and `id` `ilp` `custom` set.