### PR TITLE
refactor: use data instead of ilp, custom, and id

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -520,12 +520,14 @@ class FiveBellsLedger extends EventEmitter2 {
 
     const destinationAddress = this.ledgerContext.parseAddress(message.to)
     const fiveBellsMessage = {
-      id: message.id,
       ledger: this.ledgerContext.host,
       from: this.ledgerContext.urls.account.replace(':name', encodeURIComponent(this.username)),
       to: this.ledgerContext.urls.account.replace(':name', encodeURIComponent(destinationAddress.username)),
-      ilp: message.ilp,
-      custom: message.custom
+      data: {
+        id: message.id,
+        ilp: message.ilp,
+        custom: message.custom
+      }
     }
     debug('converted to ledger message: ' + JSON.stringify(fiveBellsMessage))
 

--- a/src/lib/translate.js
+++ b/src/lib/translate.js
@@ -277,11 +277,7 @@ const translateTransferNotification = (
   }
 }
 
-const translateMessageNotification = (_message, account, ledgerContext) => {
-  const message = Object.assign({}, _message)
-
-  // remove any null value for message data
-  if (!message.data) delete message.data
+const translateMessageNotification = (message, account, ledgerContext) => {
   validateMessage(message, ledgerContext)
 
   return [
@@ -290,10 +286,10 @@ const translateMessageNotification = (_message, account, ledgerContext) => {
       ledger: ledgerContext.prefix,
       from: ledgerContext.prefix + ledgerContext.accountUriToName(message.from),
       to: ledgerContext.prefix + ledgerContext.accountUriToName(message.to),
-      ilp: message.ilp || (message.data && message.data.ilp),
-      custom: message.custom || (message.data && message.data.custom)
+      ilp: message.data && message.data.ilp,
+      custom: message.data && message.data.custom
     },
-    message.id || (message.data && message.data.id)
+    message.data && message.data.id
   ]
 }
 

--- a/test/data/message.json
+++ b/test/data/message.json
@@ -1,8 +1,10 @@
 {
-  "id": "6a13abf0-2333-4d1e-9afc-5bf32c6dc0dd",
   "ledger": "http://red.example",
   "from": "http://red.example/accounts/mike",
   "to": "http://red.example/accounts/alice",
-  "ilp": "aGVsbG8=",
-  "custom": { "foo": "bar" }
+  "data": {
+    "id": "6a13abf0-2333-4d1e-9afc-5bf32c6dc0dd",
+    "ilp": "aGVsbG8=",
+    "custom": { "foo": "bar" }
+  }
 }

--- a/test/factorySpec.js
+++ b/test/factorySpec.js
@@ -434,7 +434,7 @@ describe('PluginBellsFactory', function () {
             from: 'http://red.example/accounts/mike',
             to: 'http://red.example/accounts/alice',
             ledger: 'http://red.example',
-            custom: { foo: 'bar' }
+            data: { custom: { foo: 'bar' } }
           })
           .matchHeader('authorization', 'Bearer abc')
           .reply(200)

--- a/test/messageSpec.js
+++ b/test/messageSpec.js
@@ -284,8 +284,8 @@ describe('Messaging', function () {
           assert.equal(message.ledger, this.ledgerMessage.ledger)
           assert.equal(message.from, this.ledgerMessage.from)
           assert.equal(message.to, this.ledgerMessage.to)
-          assert.equal(message.id, this.ledgerMessage.id)
-          assert.deepEqual(IlpPacket.deserializeIlpError(Buffer.from(message.ilp, 'base64')), {
+          assert.equal(message.data.id, this.ledgerMessage.data.id)
+          assert.deepEqual(IlpPacket.deserializeIlpError(Buffer.from(message.data.ilp, 'base64')), {
             code: 'F00',
             name: 'Bad Request',
             triggeredBy: 'example.red.mike',
@@ -308,7 +308,7 @@ describe('Messaging', function () {
     it('relays an error message to the ledger if no response is returned', function * () {
       nock('http://red.example')
         .post('/messages', (message) => {
-          assert.deepEqual(IlpPacket.deserializeIlpError(Buffer.from(message.ilp, 'base64')), {
+          assert.deepEqual(IlpPacket.deserializeIlpError(Buffer.from(message.data.ilp, 'base64')), {
             code: 'F00',
             name: 'Bad Request',
             triggeredBy: 'example.red.mike',

--- a/test/notificationSpec.js
+++ b/test/notificationSpec.js
@@ -579,10 +579,10 @@ describe('Notification handling', function () {
         .post('/messages', this.fiveBellsMessage)
         .matchHeader('authorization', 'Bearer abc')
         .reply(200)
-      const requestMessage = Object.assign({id: this.fiveBellsMessage.id}, this.message)
+      const requestMessage = Object.assign({id: this.fiveBellsMessage.data.id}, this.message)
       const responseMessage = Object.assign({}, this.message, {custom: {response: true}})
       setTimeout(() => {
-        this.plugin.emit('incoming_message', responseMessage, this.fiveBellsMessage.id)
+        this.plugin.emit('incoming_message', responseMessage, this.fiveBellsMessage.data.id)
       }, 10)
 
       yield assert.eventually.deepEqual(this.plugin.sendRequest(requestMessage), responseMessage)


### PR DESCRIPTION
The change to `ilp`, `id`, and `custom` causes un-needed change in the schemas